### PR TITLE
Added docker support and cleaned readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:21-alpine
 
-RUN mkdir -p /opt/app
-WORKDIR /opt/app
+RUN mkdir -p /app
+WORKDIR /app
 
 COPY package.json package-lock.json ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-bookworm
+FROM node:21-alpine
 
 RUN mkdir -p /opt/app
 WORKDIR /opt/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:21-bookworm
+
+RUN mkdir -p /opt/app
+WORKDIR /opt/app
+
+COPY package.json package-lock.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 2052
+
+CMD ["node", "."]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ This project was made with the goal to combine TeamSpeak and Discord. The goal: 
 
 Since you can host the server yourself you're also the one in control of the data. This could be important for people who value their data privacy.
 
----
+
 
 ## Licensing
-The software will be free for personal use and for non-profit communities. Commercial use will require a license (or maybe not). 
+The software will be free for personal use and for non-profit communities. Commercial use will require a license (or maybe not).   
 
 ---
 
-## How to install
+## Installing
 ### Docker
 To install via docker you can either clone and build or use the prebuilt image.
 ```
@@ -27,23 +27,23 @@ $ sudo docker compose up -d
 ```
 
 ### NPM
-Requires node.js to be installed (tested with v16.16.0). Afterwards execute the following commands inside the app's directory.
+Requires node.js to be installed, see [Tested Versions](https://github.com/t2vee/dcts-shipping/tree/docker-support?tab=readme-ov-file#tested-versions). Clone the git repository and execute the following commands inside the app's directory.
 ```
+$ git clone https://github.com/hackthedev/dcts-shipping --depth 1
 $ npm install
 $ node .
 ```
 
----
-## Tested Versions
-- ✔️ v18.20.2
-- ✔️ v16.16.0 
-- 🚫 v12.22.9 
-
----
-
 ## Connecting to your server
 Once you've installed the server and its running, you can open your browser and enter the server's ip and add the port 2052.<br>
 Example: localhost:2052
+
+---
+
+## Tested Versions
+- ✔️ v18.20.2
+- ✔️ v16.16.0
+- 🚫 v12.22.9
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ This project was made with the goal to combine TeamSpeak and Discord. The goal: 
 
 Since you can host the server yourself you're also the one in control of the data. This could be important for people who value their data privacy.
 
-
+<br>
 
 ## Licensing
 The software will be free for personal use and for non-profit communities. Commercial use will require a license (or maybe not).   
 
----
+<br>
 
 ## Installing
 ### Docker
@@ -26,6 +26,7 @@ $ curl -L -O https://github.com/t2vee/dcts-shipping/raw/docker-support/docker/do
 $ sudo docker compose up -d
 ```
 
+
 ### NPM
 Requires node.js to be installed, see [Tested Versions](https://github.com/t2vee/dcts-shipping/tree/docker-support?tab=readme-ov-file#tested-versions). Clone the git repository and execute the following commands inside the app's directory.
 ```
@@ -34,18 +35,21 @@ $ npm install
 $ node .
 ```
 
+<br>
+
 ## Connecting to your server
 Once you've installed the server and its running, you can open your browser and enter the server's ip and add the port 2052.<br>
 Example: localhost:2052
 
----
+<br>
 
 ## Tested Versions
+- ✔️ v21.7.3
 - ✔️ v18.20.2
 - ✔️ v16.16.0
 - 🚫 v12.22.9
 
----
+<br>
 
 ## Tutorial
 (version in video slightly outdated)<br>

--- a/README.md
+++ b/README.md
@@ -7,31 +7,45 @@ This project was made with the goal to combine TeamSpeak and Discord. The goal: 
 
 Since you can host the server yourself you're also the one in control of the data. This could be important for people who value their data privacy.
 
-<br>
+---
 
 ## Licensing
 The software will be free for personal use and for non-profit communities. Commercial use will require a license (or maybe not). 
 
-<br>
+---
 
 ## How to install
-Requires node.js to be installed (tested with v16.16.0). Afterwards execute the following commands inside the app's directory.
+### Docker
+To install via docker you can either clone and build or use the prebuilt image.
 ```
-npm install
-node .
+$ sudo docker run --name dcts-server  -p 8080:2052 ghcr.io/t2vee/dcts
+```
+or via docker-compose:
+```
+$ curl -L -O https://github.com/t2vee/dcts-shipping/raw/docker-support/docker/docker-compose.yml
+$ sudo docker compose up -d
 ```
 
+### NPM
+Requires node.js to be installed (tested with v16.16.0). Afterwards execute the following commands inside the app's directory.
+```
+$ npm install
+$ node .
+```
+
+---
 ## Tested Versions
+- ✔️ v18.20.2
 - ✔️ v16.16.0 
 - 🚫 v12.22.9 
 
-<br>
+---
 
 ## Connecting to your server
 Once you've installed the server and its running, you can open your browser and enter the server's ip and add the port 2052.<br>
 Example: localhost:2052
 
-<br>
+---
 
 ## Tutorial
 (version in video slightly outdated)<br>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+services:
+  dcts:
+    image: ghcr.io/t2vee/dcts
+    restart: always
+    ports:
+      - '8080:2052'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,5 +3,10 @@ services:
   dcts:
     image: ghcr.io/t2vee/dcts
     restart: always
+    volumes:
+      - dcts:/app/chats
     ports:
       - '8080:2052'
+
+volumes:
+  dcts:


### PR DESCRIPTION
This is a simple pull request to allow dcts to be deployed via docker using `docker run` or `docker compose`.
For now its just a simple node image but in the future I will add support for configuration and other features as dcts grows.

also made some qol changes to the readme to make it a little cleaner

TODO:
- add support for https mode