### PR TITLE
Add beta branch to Docker workflow triggers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - beta
 
 jobs:
   build:


### PR DESCRIPTION
I believe this could resolve Issue #38, as the Docker image builds previously only worked when pushing to the main branch, but now they also work for the beta branch.

**Please correct me if I'm wrong :o**