### PR TITLE
Fixed bug where marker doesn't disappear after channel has been read.

### DIFF
--- a/public/js/messages/server/messages.js
+++ b/public/js/messages/server/messages.js
@@ -1212,6 +1212,7 @@ function getChatlog(container, index = -1, appendTop = false, scrollPosition = n
         }
 
         ChatManager.setChannelMarkerCounter(UserManager.getChannel())
+        ChatManager.setChannelMarker(UserManager.getChannel(), false)
 
         if (!appendTop) {
             displayAwaitedMessages(container)


### PR DESCRIPTION
https://github.com/user-attachments/assets/5625c240-e3b2-4ab5-9aef-a731d8515e87

