### PR TITLE
Fix issue with embeds when there are no meta tags in the html document

### DIFF
--- a/public/js/markdown.js
+++ b/public/js/markdown.js
@@ -177,7 +177,8 @@ async function markdown(msg, msgid) {
             continue;
         }
 
-        let embed = `
+        if (urlMeta?.meta?.title || urlMeta?.meta?.description) {
+            let embed = `
             <div class="markdown-urlEmbed-container">
                 <a class="markdown-urlEmbed"
                    data-media-type="link"
@@ -192,7 +193,14 @@ async function markdown(msg, msgid) {
                 </a>
             </div>`;
 
-        msg = msg.replace(url, embed);
+            msg = msg.replace(url, embed);
+            changed = true;
+            continue;
+        }
+
+        msg = msg.replace(url,
+            `<a draggable="false" data-media-type="link" data-message-id="${msgid.replace("msg-", "")}" href="${url}" ${url.startsWith(location.origin) ? "" : "target=\"_blank\""}> ${url} </a>`
+        );
         changed = true;
     }
 

--- a/public/js/markdown.js
+++ b/public/js/markdown.js
@@ -199,7 +199,7 @@ async function markdown(msg, msgid) {
         }
 
         msg = msg.replace(url,
-            `<a draggable="false" data-media-type="link" data-message-id="${msgid.replace("msg-", "")}" href="${url}" ${url.startsWith(location.origin) ? "" : "target=\"_blank\""}> ${url} </a>`
+            `<a draggable="false" data-media-type="link" data-message-id="${msgid.replace("msg-", "")}" href="${url}" ${url.startsWith(location.origin) ? "" : "target=\"_blank\""}> ${unescapeHtmlEntities(sanitizeHtmlForRender(url))} </a>`
         );
         changed = true;
     }


### PR DESCRIPTION
This PR fixes an issue with URL embeds where if there were no meta tags for title or description in the document at a given URL it would render a blank embed instead of a link

Now, if there are no tags, it will fall back to rendering the URL as a clickable link instead of a blank embed;

<img width="590" height="214" alt="image" src="https://github.com/user-attachments/assets/be1fbb93-6168-424e-b358-f66740af8ef8" />

@hackthedev I'm not sure if I was supposed to pass $url through the sanitization functions or not, if I did it wrong just let me know and I'll change it to just `$(url)` before you merge