### PR TITLE
Fix/member list image display

### DIFF
--- a/modules/sockets/getMemberList.mjs
+++ b/modules/sockets/getMemberList.mjs
@@ -13,11 +13,17 @@ export default (io) => (socket) => {
                 return;
             }
 
-            if(!member?.channel) return response({ members: {}, index: 0, error: "No channel id provided" });
-
-            let {members, index} = await getMemberList(member, member?.channel, member?.lastIndex);
-            
-            response({ members, index })
+            if(!member?.channel) {
+                if(member?.group) {
+                    let {members, index} = await getMemberList(member, member?.group, member?.lastIndex);
+                    response({ members, index })
+                } else {
+                    return response({ members: {}, index: 0, error: "No channel id provided" });
+                }
+            } else {
+                let {members, index} = await getMemberList(member, member?.channel, member?.lastIndex);
+                response({ members, index })
+            }   
         }
     });
 }

--- a/public/js/core/memberlist.js
+++ b/public/js/core/memberlist.js
@@ -4,8 +4,6 @@ function getMemberList() {
     let infolist = document.getElementById("infolist");
     if(localStorage.getItem("memberlist_html_cache") && infolist?.innerText?.trim()?.length  === 0) infolist.innerHTML = localStorage.getItem("memberlist_html_cache");
 
-    if(!UserManager.getChannel()) return;
-
     Clock.start("memberlist_request")
     socket.emit("getMemberList", {
         id: UserManager.getID(),

--- a/public/js/core/memberlist.js
+++ b/public/js/core/memberlist.js
@@ -239,7 +239,7 @@ function getMemberList() {
 
     function getMemberHTML(member, role){
         return `<div class="memberlist-container" data-member-id="${member.id}">
-                        <img draggable="false" class="memberlist-img ${member?.isOffline ? "offline_pfp" : ""}" data-member-id="${member.id}" src="${ChatManager.proxyUrl(sanitizeHtmlForRender(member.icon))}" onerror="this.src = '/img/default_pfp.png'">
+                        <img draggable="false" class="memberlist-img ${member?.isOffline ? "offline_pfp" : ""}" data-member-id="${member.id}" src="${ChatManager.proxyUrl(member.icon)}" this.onerror=null;this.src='/img/default_pfp.png'">
                         
                         <div style="display:flex;flex-direction: column;width: calc(100% - 35px);">
                             <div class="memberlist-member-info name" 


### PR DESCRIPTION
[First commit](https://github.com/hackthedev/dcts-shipping/commit/7eff39ed58b67b6aa3755ead91902800d2241335) prevents member icon URLs from breaking due to HTML sanitise being applied to hem.
[Second commit](https://github.com/hackthedev/dcts-shipping/commit/429db93a1d68c83f953ee132ea567878c9c7740c) Ensures member list is refreshed even when user clicks on a group or exits settings so that the changed image immediately displays.

Addresses [Bug 270](https://github.com/hackthedev/dcts-shipping/issues/270)

https://github.com/user-attachments/assets/c77e3485-e20f-4326-820c-a9b2e74a0db5

