### PR TITLE
Add a server side timeout for fetching media message metadata.

### DIFF
--- a/modules/functions/mysql/helper.mjs
+++ b/modules/functions/mysql/helper.mjs
@@ -359,7 +359,8 @@ export async function getStringSizeInMegabytes(str) {
 // Same as in chat.js
 export async function checkMediaTypeAsync(url) {
     try {
-        const response = await fetch(url, {method: 'HEAD'});
+        const timeout_ms = serverconfig.serverinfo.fetch?.timeout_ms || 1000;
+        const response = await fetch(url, {method: 'HEAD', signal: AbortSignal.timeout(timeout_ms)});
 
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
It appears that the default timeout for fetch is 2 minutes, and this method is invoked via socket message when opening a channel.  This means that if a channel is opened where lots of images are referring to a server that is currently down, opening the channel can easily take many minutes until anything is displayed whatsoever (except for new messages, which are still delivered on time).

For most cases, a timeout of 1 second should be plenty for fetching messages, and seems like a good compromise between leaving too much time for unresponsive servers, and making it impossible to load image heavy channels. In any case though, this change reads the setting from the configuration file, allowing server operators to adjust them as they see fit.