### PR TITLE
Add a timeout to client side Content-Type discovery.

### DIFF
--- a/public/js/markdown.js
+++ b/public/js/markdown.js
@@ -264,10 +264,12 @@ async function checkMediaTypeAsync(url) {
                 resolve(response.mediaType);
             } else {
                 // url wasnt cached
+                let serverinfo = getServerInfo();
                 let xhr = new XMLHttpRequest();
-                xhr.open('HEAD', `${ChatManager.proxyUrl(url)}`, false); // false makes the request synchronous
-                try {
-                    xhr.send();
+
+                xhr.timeout = serverinfo?.fetch?.timeout_ms || 1000;
+                xhr.open('HEAD', `${ChatManager.proxyUrl(url)}`, true);
+                xhr.onload = function(e) {
                     if (xhr.status >= 200 && xhr.status < 300) {
                         let contentType = xhr.getResponseHeader('Content-Type');
 
@@ -282,14 +284,28 @@ async function checkMediaTypeAsync(url) {
                                 resolve('unknown');
                             }
                         } else {
-                            console.log("Content-Type missing")
-                            throw new Error('Content-Type header is missing');
+                            console.error('Content-Type missing');
+                            resolve('error');
                         }
                     } else {
                         if (xhr.status === 404) resolve ("404");
 
-                        throw new Error(`HTTP error! status: ${xhr.status}`);
+                        console.error(`HTTP error status: ${xhr.status}`);
+                        resolve('error');
                     }
+                }
+
+                xhr.onerror = function(e) {
+                    console.error('XMLHttpRequest error');
+                    resolve('error');
+                }
+
+                xhr.ontimeout = function(e) {
+                    console.error('Request timed out');
+                    resolve('error');
+                }
+                try {
+                    xhr.send();
                 } catch (error) {
                     resolve('error');
                 }


### PR DESCRIPTION
For determining the content type of site objects we haven't cached, we are launching XMLHttpRequests in a promise that we are waiting for synchronously when loading a new channel. However, the synchronous XMLHttpRequest API doesn't support timeouts, and it seems to time out by itself after exactly one minute. This means that without this change, we are adding up to a minute of wait time for each uncached object in a channel.

The impact of this can add up significantly when a channel has a lot of images that are loaded from an external source that is not currently reachable.

For most cases, a timeout of 1 second should be plenty for fetching messages, and seems like a good compromise between leaving enough time for unresponsive servers, and making it impossible to load image heavy channels. (Note that this timeout applies *after* the server has already attempted to fetch this data, which adds another 2 minutes by default.) In any case though, this change reads the setting from the server configuration, allowing server operators to adjust the timeout as they see fit.