### PR TITLE
Replace remaining native browser dialogs (follow-up to #119)

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -637,13 +637,19 @@ function getMemberProfile(id, x, y, event = null, bypassEventCheck = false) {
 
 
 function redeemKey() {
-    var key = prompt("Enter the key you want to redeem");
+    DialogManager.prompt({
+        title: "Redeem Key",
+        label: "Key",
+        placeholder: "Enter the key you want to redeem",
+        submitText: "Redeem",
+        submitColor: "success",
+        minWidth: 360,
+    }).then((key) => {
+        const trimmedKey = key?.trim();
+        if (!trimmedKey) return;
 
-    if (key == null || key.length <= 0) {
-
-    } else {
-        socket.emit("redeemKey", { id: UserManager.getID(), key: key, token: UserManager.getToken() });
-    }
+        socket.emit("redeemKey", { id: UserManager.getID(), key: trimmedKey, token: UserManager.getToken() });
+    });
 }
 
 function dataURLtoBlob(dataUrl) {

--- a/public/chat.js
+++ b/public/chat.js
@@ -637,7 +637,7 @@ function getMemberProfile(id, x, y, event = null, bypassEventCheck = false) {
 
 
 function redeemKey() {
-    DialogManager.prompt({
+    customPrompts.showInput({
         title: "Redeem Key",
         label: "Key",
         placeholder: "Enter the key you want to redeem",

--- a/public/js/channels/channels.js
+++ b/public/js/channels/channels.js
@@ -34,7 +34,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 callback: async (data) => {
                     let categoryId = getCategoryIdFromElement(data.element);
                     if(!categoryId){
-                        DialogManager.alert("Category not found", {title: "Create Channel"});
+                        customPrompts.showAlert("Category not found", {title: "Create Channel"});
                         console.error("Cant create channel in category because couldnt find category id from element");
                         return;
                     }

--- a/public/js/channels/channels.js
+++ b/public/js/channels/channels.js
@@ -34,7 +34,7 @@ document.addEventListener("DOMContentLoaded", function () {
                 callback: async (data) => {
                     let categoryId = getCategoryIdFromElement(data.element);
                     if(!categoryId){
-                        alert("not found")
+                        DialogManager.alert("Category not found", {title: "Create Channel"});
                         console.error("Cant create channel in category because couldnt find category id from element");
                         return;
                     }

--- a/public/js/core/RichEditor.js
+++ b/public/js/core/RichEditor.js
@@ -55,8 +55,17 @@ class RichEditor {
                     handlers: {
                         link: value => {
                             if (!value) return this.quill.format("link", false);
-                            const href = prompt("Enter the URL");
-                            if (href) this.quill.format("link", href);
+                            DialogManager.prompt({
+                                title: "Insert Link",
+                                label: "URL",
+                                placeholder: "Enter the URL",
+                                submitText: "Insert",
+                                submitColor: "success",
+                                minWidth: 360,
+                            }).then((href) => {
+                                const trimmedHref = href?.trim();
+                                if (trimmedHref) this.quill.format("link", trimmedHref);
+                            });
                         }
                     }
                 },

--- a/public/js/core/RichEditor.js
+++ b/public/js/core/RichEditor.js
@@ -55,7 +55,7 @@ class RichEditor {
                     handlers: {
                         link: value => {
                             if (!value) return this.quill.format("link", false);
-                            DialogManager.prompt({
+                            customPrompts.showInput({
                                 title: "Insert Link",
                                 label: "URL",
                                 placeholder: "Enter the URL",

--- a/public/js/core/UserManager.js
+++ b/public/js/core/UserManager.js
@@ -256,7 +256,7 @@ class UserManager {
     }
 
     static changeStatus() {
-        DialogManager.prompt({
+        customPrompts.showInput({
             title: "Change Status",
             label: "Status",
             value: UserManager.getStatus() || "",
@@ -272,13 +272,13 @@ class UserManager {
                 CookieManager.setCookie("status", trimmedStatus, 360);
                 UserManager.updateStatusOnUI(trimmedStatus, true);
             } else {
-                DialogManager.alert("Your status was too short", {title: "Invalid Status"});
+                customPrompts.showAlert("Your status was too short", {title: "Invalid Status"});
             }
         });
     }
 
     static changePFP() {
-        DialogManager.prompt({
+        customPrompts.showInput({
             title: "Change Profile Picture",
             label: "Profile Image URL",
             value: UserManager.getPFP() || "",
@@ -301,7 +301,7 @@ class UserManager {
                 return;
             }
 
-            DialogManager.confirm("Your pfp url was too short. Want to reset your pfp?", {
+            customPrompts.showConfirmPrompt("Your pfp url was too short. Want to reset your pfp?", {
                 title: "Reset Profile Picture",
                 confirmText: "Reset",
                 confirmColor: "error",
@@ -351,7 +351,7 @@ class UserManager {
     }
 
     static getPassword() {
-        return DialogManager.prompt({
+        return customPrompts.showInput({
             title: "Password Required",
             label: "Password",
             placeholder: "Please enter your account password",
@@ -573,7 +573,7 @@ class UserManager {
 
     static importToken() {
         /* DEPRECATED */
-        DialogManager.prompt({
+        customPrompts.showInput({
             title: "Import Token",
             label: "Exported Token",
             placeholder: "Please paste your exported token here",
@@ -589,22 +589,22 @@ class UserManager {
             console.log(token)
 
             if (token.length != 48) {
-                DialogManager.alert("This token was invalid. If you forgot your token please contact the server admin", {title: "Invalid Token"});
+                customPrompts.showAlert("This token was invalid. If you forgot your token please contact the server admin", {title: "Invalid Token"});
                 return;
             }
             if (id.length != 12) {
-                DialogManager.alert("The ID in your token string was invalid. Format: token:id (48, 12)", {title: "Invalid Token ID"});
+                customPrompts.showAlert("The ID in your token string was invalid. Format: token:id (48, 12)", {title: "Invalid Token ID"});
                 return;
             }
 
-            DialogManager.alert("Token successfully set!\nPlease save it if you havent already", {title: "Token Imported"});
+            customPrompts.showAlert("Token successfully set!\nPlease save it if you havent already", {title: "Token Imported"});
             CookieManager.setCookie("dcts_token", token, 365);
             CookieManager.setCookie("id", id, 365);
         });
     }
 
     static resetAccount() {
-        DialogManager.confirm("Do you really wanna logout?", {
+        customPrompts.showConfirmPrompt("Do you really wanna logout?", {
             title: "Logout",
             confirmText: "Logout",
             confirmColor: "error",

--- a/public/js/core/UserManager.js
+++ b/public/js/core/UserManager.js
@@ -256,40 +256,64 @@ class UserManager {
     }
 
     static changeStatus() {
-        var status = prompt("What should your new status be?", getStatus());
+        DialogManager.prompt({
+            title: "Change Status",
+            label: "Status",
+            value: UserManager.getStatus() || "",
+            placeholder: "What should your new status be?",
+            submitText: "Save",
+            submitColor: "success",
+            minWidth: 360,
+        }).then((status) => {
+            if (status == null) return;
 
-        if (status.length > 0) {
-            CookieManager.setCookie("status", status, 360);
-            UserManager.updateStatusOnUI(status, true);
-        } else {
-            alert("Your status was too short");
-        }
+            const trimmedStatus = status.trim();
+            if (trimmedStatus.length > 0) {
+                CookieManager.setCookie("status", trimmedStatus, 360);
+                UserManager.updateStatusOnUI(trimmedStatus, true);
+            } else {
+                DialogManager.alert("Your status was too short", {title: "Invalid Status"});
+            }
+        });
     }
 
     static changePFP() {
-        var pfp = prompt("Enter the url of your new pfp", getPFP());
+        DialogManager.prompt({
+            title: "Change Profile Picture",
+            label: "Profile Image URL",
+            value: UserManager.getPFP() || "",
+            placeholder: "Enter the url of your new pfp",
+            submitText: "Save",
+            submitColor: "success",
+            minWidth: 420,
+        }).then((pfp) => {
+            if (pfp == null) return;
 
-        if (pfp.length > 0) {
-            CookieManager.setCookie("pfp", pfp, 360);
-            UserManager.updatePFPOnUI(pfp, true);
-        } else {
+            const trimmedPfp = pfp.trim();
+            if (trimmedPfp.length > 0) {
+                let resolvedPfp = trimmedPfp;
+                if (isImage(resolvedPfp) == false) {
+                    resolvedPfp = "/img/default_pfp.png";
+                }
 
-            var reset = confirm("Your pfp url was too short. Want to reset your pfp?");
-
-            if (reset) {
-                pfp = "/img/default_pfp.png";
-                setPFP(pfp);
-            } else {
+                CookieManager.setCookie("pfp", resolvedPfp, 360);
+                UserManager.updatePFPOnUI(resolvedPfp, true);
                 return;
             }
-        }
 
-        if (pfp == null || isImage(pfp) == false) {
-            pfp = "/img/default_pfp.png";
-        }
+            DialogManager.confirm("Your pfp url was too short. Want to reset your pfp?", {
+                title: "Reset Profile Picture",
+                confirmText: "Reset",
+                confirmColor: "error",
+            }).then((reset) => {
+                if (!reset) return;
 
-        CookieManager.setCookie("pfp", pfp, 360);
-        UserManager.updatePFPOnUI(pfp, true);
+                const defaultPfp = "/img/default_pfp.png";
+                UserManager.setPFP(defaultPfp);
+                CookieManager.setCookie("pfp", defaultPfp, 360);
+                UserManager.updatePFPOnUI(defaultPfp, true);
+            });
+        });
     }
 
     static changeUsername() {
@@ -327,8 +351,15 @@ class UserManager {
     }
 
     static getPassword() {
-        let passprompt = prompt("Please enter your account password:");
-        if (passprompt) return passprompt;
+        return DialogManager.prompt({
+            title: "Password Required",
+            label: "Password",
+            placeholder: "Please enter your account password",
+            type: "password",
+            submitText: "Continue",
+            submitColor: "success",
+            minWidth: 360,
+        });
     }
 
     static getTheme() {
@@ -542,31 +573,44 @@ class UserManager {
 
     static importToken() {
         /* DEPRECATED */
-        var combinedInput = prompt("Please paste your exported token here.")
+        DialogManager.prompt({
+            title: "Import Token",
+            label: "Exported Token",
+            placeholder: "Please paste your exported token here",
+            submitText: "Import",
+            submitColor: "success",
+            minWidth: 460,
+        }).then((combinedInput) => {
+            if (!combinedInput) return;
 
-        var token = combinedInput.split(":")[0];
-        var id = combinedInput.split(":")[1];
+            const token = combinedInput.split(":")[0] || "";
+            const id = combinedInput.split(":")[1] || "";
 
-        console.log(token)
+            console.log(token)
 
-        if (token.length != 48) {
-            alert("This token was invalid. If you forgot your token please contact the server admin");
-            return;
-        }
-        if (id.length != 12) {
-            alert("The ID in your token string was invalid. Format: token:id (48, 12)");
-            return;
-        }
+            if (token.length != 48) {
+                DialogManager.alert("This token was invalid. If you forgot your token please contact the server admin", {title: "Invalid Token"});
+                return;
+            }
+            if (id.length != 12) {
+                DialogManager.alert("The ID in your token string was invalid. Format: token:id (48, 12)", {title: "Invalid Token ID"});
+                return;
+            }
 
-        alert("Token successfully set!\nPlease save it if you havent already");
-        CookieManager.setCookie("dcts_token", token, 365);
-        CookieManager.setCookie("id", id, 365);
+            DialogManager.alert("Token successfully set!\nPlease save it if you havent already", {title: "Token Imported"});
+            CookieManager.setCookie("dcts_token", token, 365);
+            CookieManager.setCookie("id", id, 365);
+        });
     }
 
     static resetAccount() {
-        var reset = confirm("Do you really wanna logout?")
+        DialogManager.confirm("Do you really wanna logout?", {
+            title: "Logout",
+            confirmText: "Logout",
+            confirmColor: "error",
+        }).then((reset) => {
+            if (!reset) return;
 
-        if (reset) {
             CookieManager.setCookie("id", null, 365);
             CookieManager.setCookie("username", null, 365);
             CookieManager.setCookie("status", null, 365);
@@ -577,7 +621,7 @@ class UserManager {
             CookieManager.setCookie("pow_solution", null, 365);
 
             window.location.href = window.location.origin;
-        }
+        });
     }
 
     static setUsername(username) {

--- a/public/js/messages/server/messages.js
+++ b/public/js/messages/server/messages.js
@@ -572,10 +572,18 @@ function initQuillShit(customQuill = null){
                 container: '#editor-toolbar', handlers: {
                     'link': function (value) {
                         if (value) {
-                            var href = prompt('Enter the URL');
-                            if (href) {
-                                quill.format('link', href);
-                            }
+                            customPrompts.showInput({
+                                title: "Insert Link",
+                                label: "URL",
+                                placeholder: "https://example.com",
+                                defaultValue: quill.getFormat()?.link || "",
+                                submitText: "Insert"
+                            }, href => {
+                                href = href?.trim();
+                                if (href) {
+                                    quill.format('link', href);
+                                }
+                            });
                         } else {
                             quill.format('link', false);
                         }

--- a/public/js/prompts.js
+++ b/public/js/prompts.js
@@ -6,9 +6,9 @@ class Prompt {
         this.afterSubmitAction = null;
         this.selectedValues = []; // Store selected values for select feature
         this.multiSelect = false; // Single or multi-select mode
-        this.closePrompt();
         window.__promptInstance = this;
         window.__prompt = this;
+        this.closePrompt();
     }
 
     addStyles() {
@@ -408,11 +408,9 @@ class Prompt {
 
     closePrompt(canceled = true) {
         const afterSubmitAction = this.afterSubmitAction;
-
         this.modal.style.display = 'none';
         this.currentCallback = null;
         this.afterSubmitAction = null;
-
         if (canceled && afterSubmitAction) {
             afterSubmitAction({ canceled, values: null });
         }

--- a/public/js/prompts.js
+++ b/public/js/prompts.js
@@ -3,9 +3,12 @@ class Prompt {
         this.addStyles();  // Add the custom styles
         this.createModal();
         this.currentCallback = null;
+        this.afterSubmitAction = null;
         this.selectedValues = []; // Store selected values for select feature
         this.multiSelect = false; // Single or multi-select mode
         this.closePrompt();
+        window.__promptInstance = this;
+        window.__prompt = this;
     }
 
     addStyles() {
@@ -280,7 +283,7 @@ class Prompt {
         this.selectedValues = multiSelect ? [] : null;
         this.promptContent.innerHTML = htmlContent;
         this.modal.style.display = 'flex';
-        this.promptContent.style.minWidth = `${customMinWidth}px` || "";
+        this.promptContent.style.minWidth = customMinWidth ? `${customMinWidth}px` : "";
 
         // reset colors just in case
         this.modalContent.style.backgroundColor = '#24292E';
@@ -327,7 +330,7 @@ class Prompt {
         }
     }
 
-    showConfirm(titleText, options, callback, afterSubmitAction = null) {
+    showConfirm(titleText, options, callback, afterSubmitAction = null, bodyHtml = '') {
         this.currentCallback = callback;
         this.afterSubmitAction = afterSubmitAction;
 
@@ -336,7 +339,7 @@ class Prompt {
             titleElement.innerText = titleText;
         }
 
-        this.promptContent.innerHTML = '';
+        this.promptContent.innerHTML = bodyHtml || '';
         this.submitButton.style.display = 'none';
         this.helpButton.style.display = 'none';
         this.closeButton.style.display = 'none';
@@ -404,13 +407,15 @@ class Prompt {
     }
 
     closePrompt(canceled = true) {
+        const afterSubmitAction = this.afterSubmitAction;
+
         this.modal.style.display = 'none';
-
-        if (this.afterSubmitAction) {
-            this.afterSubmitAction({ canceled, values: null });
-        }
-
         this.currentCallback = null;
+        this.afterSubmitAction = null;
+
+        if (canceled && afterSubmitAction) {
+            afterSubmitAction({ canceled, values: null });
+        }
     }
 
     previewImage(event) {
@@ -446,21 +451,164 @@ class Prompt {
             }
         });
 
-        const callbackResult = this.currentCallback ? this.currentCallback(values) : undefined;
-
-        if (this.currentCallback) {
-            this.currentCallback = null;
-        }
+        const currentCallback = this.currentCallback;
+        const afterSubmitAction = this.afterSubmitAction;
+        const callbackResult = currentCallback ? currentCallback(values) : undefined;
 
         if (callbackResult === false) return;
 
-        if (this.afterSubmitAction) {
-            this.afterSubmitAction({ canceled: false, values });
+        this.currentCallback = null;
+        this.afterSubmitAction = null;
+
+        if (afterSubmitAction) {
+            afterSubmitAction({ canceled: false, values });
         }
 
-        this.closePrompt(false);
+        this.modal.style.display = 'none';
     }
 
 
 
 }
+Prompt.escapeHtml = function (value) {
+    return String(value ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
+};
+
+Prompt.textToHtml = function (value) {
+    return `<p style="margin:0 0 10px 0;line-height:1.5;">${Prompt.escapeHtml(value).replaceAll("\n", "<br>")}</p>`;
+};
+
+Prompt.prototype.showInput = function (titleOrOptions = {}, callback = null, extraOptions = {}) {
+    const options = typeof titleOrOptions === "object" && titleOrOptions !== null
+        ? titleOrOptions
+        : { title: titleOrOptions, callback, ...extraOptions };
+    const inputId = `prompt-input-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const {
+        title = "Prompt",
+        label = "",
+        message = "",
+        name = "value",
+        value = "",
+        placeholder = "",
+        type = "text",
+        submitText = "Submit",
+        submitColor = null,
+        minWidth = 280,
+        multiline = false,
+        rows = 6,
+        callback: inputCallback = typeof callback === "function" ? callback : null,
+    } = options;
+    const escapedValue = Prompt.escapeHtml(value);
+    const escapedPlaceholder = Prompt.escapeHtml(placeholder);
+    const escapedLabel = Prompt.escapeHtml(label);
+    const bodyHtml = `
+        ${message ? Prompt.textToHtml(message) : ""}
+        <div class="prompt-form-group">
+            ${label ? `<label class="prompt-label" for="${inputId}">${escapedLabel}</label>` : ""}
+            ${multiline
+                ? `<textarea class="prompt-input" id="${inputId}" name="${name}" rows="${rows}" placeholder="${escapedPlaceholder}">${escapedValue}</textarea>`
+                : `<input class="prompt-input" type="${type}" id="${inputId}" name="${name}" value="${escapedValue}" placeholder="${escapedPlaceholder}">`
+            }
+        </div>
+    `;
+
+    return new Promise((resolve) => {
+        let settled = false;
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+        };
+
+        this.showPrompt(
+            title,
+            bodyHtml,
+            (values) => {
+                const result = values?.[name] ?? null;
+                const callbackResult = inputCallback ? inputCallback(result, values) : undefined;
+
+                if (callbackResult === false) {
+                    return false;
+                }
+
+                finish(result);
+            },
+            [submitText, submitColor],
+            false,
+            minWidth,
+            null,
+            (state) => {
+                if (state?.canceled) {
+                    finish(null);
+                }
+            }
+        );
+
+        requestAnimationFrame(() => {
+            const input = document.getElementById(inputId);
+            if (!input) return;
+
+            input.focus();
+            if (!multiline && typeof input.select === "function") {
+                input.select();
+            }
+        });
+    });
+};
+
+Prompt.prototype.showAlert = function (message, {
+    title = "Notice",
+    buttonText = "OK",
+    buttonColor = null,
+    minWidth = 320,
+} = {}) {
+    return new Promise((resolve) => {
+        let settled = false;
+        const finish = () => {
+            if (settled) return;
+            settled = true;
+            resolve(true);
+        };
+
+        this.showPrompt(
+            title,
+            Prompt.textToHtml(message),
+            () => finish(),
+            [buttonText, buttonColor],
+            false,
+            minWidth,
+            null,
+            () => finish()
+        );
+    });
+};
+
+Prompt.prototype.showConfirmPrompt = function (message, {
+    title = "Confirm",
+    confirmText = "Yes",
+    cancelText = "No",
+    confirmColor = "success",
+    cancelColor = "error",
+} = {}) {
+    return new Promise((resolve) => {
+        let settled = false;
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+        };
+
+        this.showConfirm(
+            title,
+            [[confirmText, confirmColor], [cancelText, cancelColor]],
+            (selectedOption) => finish(selectedOption === confirmText.toLowerCase()),
+            null,
+            Prompt.textToHtml(message)
+        );
+    });
+};

--- a/public/serverlist/js/libs/prompts/prompts.js
+++ b/public/serverlist/js/libs/prompts/prompts.js
@@ -3,8 +3,11 @@ class Prompt {
         this.addStyles();  // Add the custom styles
         this.createModal();
         this.currentCallback = null;
+        this.afterSubmitAction = null;
         this.selectedValues = []; // Store selected values for select feature
         this.multiSelect = false; // Single or multi-select mode
+        window.__promptInstance = this;
+        window.__prompt = this;
         this.closePrompt();
     }
 
@@ -280,7 +283,7 @@ class Prompt {
         this.selectedValues = multiSelect ? [] : null;
         this.promptContent.innerHTML = htmlContent;
         this.modal.style.display = 'flex';
-        this.promptContent.style.minWidth = `${customMinWidth}px` || "";
+        this.promptContent.style.minWidth = customMinWidth ? `${customMinWidth}px` : "";
 
         // reset colors just in case
         this.modalContent.style.backgroundColor = '#24292E';
@@ -327,7 +330,7 @@ class Prompt {
         }
     }
 
-    showConfirm(titleText, options, callback, afterSubmitAction = null) {
+    showConfirm(titleText, options, callback, afterSubmitAction = null, bodyHtml = '') {
         this.currentCallback = callback;
         this.afterSubmitAction = afterSubmitAction;
 
@@ -336,7 +339,7 @@ class Prompt {
             titleElement.innerText = titleText;
         }
 
-        this.promptContent.innerHTML = '';
+        this.promptContent.innerHTML = bodyHtml || '';
         this.submitButton.style.display = 'none';
         this.helpButton.style.display = 'none';
         this.closeButton.style.display = 'none';
@@ -404,13 +407,14 @@ class Prompt {
     }
 
     closePrompt(canceled = true) {
+        const afterSubmitAction = this.afterSubmitAction;
         this.modal.style.display = 'none';
-
-        if (this.afterSubmitAction) {
-            this.afterSubmitAction({ canceled, values: null });
-        }
-
         this.currentCallback = null;
+        this.afterSubmitAction = null;
+
+        if (canceled && afterSubmitAction) {
+            afterSubmitAction({ canceled, values: null });
+        }
     }
 
     previewImage(event) {
@@ -446,21 +450,23 @@ class Prompt {
             }
         });
 
-        const callbackResult = this.currentCallback ? this.currentCallback(values) : undefined;
+        const currentCallback = this.currentCallback;
+        const afterSubmitAction = this.afterSubmitAction;
+        const callbackResult = currentCallback ? currentCallback(values) : undefined;
 
-        if (this.currentCallback) {
-            this.currentCallback = null;
+        if (callbackResult === false) {
+            return;
         }
 
-        if (callbackResult === false) return;
+        this.currentCallback = null;
+        this.afterSubmitAction = null;
 
-        if (this.afterSubmitAction) {
-            this.afterSubmitAction({ canceled: false, values });
+        if (afterSubmitAction) {
+            afterSubmitAction({ canceled: false, values });
         }
 
-        this.closePrompt(false);
+        this.modal.style.display = 'none';
     }
-
 
 
 }

--- a/public/settings/account/page/profile/profile.js
+++ b/public/settings/account/page/profile/profile.js
@@ -190,7 +190,7 @@ function saveSettings() {
             saveButton.style.display = "none";
         });
     } catch (error) {
-        DialogManager.alert("Error while trying to save settings: " + error, {title: "Profile Save Error"});
+        customPrompts.showAlert("Error while trying to save settings: " + error, {title: "Profile Save Error"});
         return;
     }
 }

--- a/public/settings/account/page/profile/profile.js
+++ b/public/settings/account/page/profile/profile.js
@@ -190,7 +190,7 @@ function saveSettings() {
             saveButton.style.display = "none";
         });
     } catch (error) {
-        alert("Error while trying to save settings: " + error);
+        DialogManager.alert("Error while trying to save settings: " + error, {title: "Profile Save Error"});
         return;
     }
 }

--- a/public/settings/channel/page/channel-info/channel-info.js
+++ b/public/settings/channel/page/channel-info/channel-info.js
@@ -57,7 +57,7 @@ function initChannelSettings(){
             console.log("Unable to get Channel Information");
             console.log(err);
 
-            alert("Unable to get channel info. Please try to reload slowly until it works. Known bug!");
+            DialogManager.alert("Unable to get channel info. Please try to reload slowly until it works. Known bug!", {title: "Channel Info Error"});
         }
 
     });

--- a/public/settings/channel/page/channel-info/channel-info.js
+++ b/public/settings/channel/page/channel-info/channel-info.js
@@ -57,7 +57,7 @@ function initChannelSettings(){
             console.log("Unable to get Channel Information");
             console.log(err);
 
-            DialogManager.alert("Unable to get channel info. Please try to reload slowly until it works. Known bug!", {title: "Channel Info Error"});
+            customPrompts.showAlert("Unable to get channel info. Please try to reload slowly until it works. Known bug!", {title: "Channel Info Error"});
         }
 
     });

--- a/public/settings/channel/page/channel-permissions/channel-permissions.js
+++ b/public/settings/channel/page/channel-permissions/channel-permissions.js
@@ -122,7 +122,7 @@ function removeRole() {
     console.log(currentRoleId);
 
     socket.emit("removeRoleFromChannel", { id: UserManager.getID(), token: UserManager.getToken(), role: currentRoleId, channel: currentChannelId }, function (response) {
-        DialogManager.alert(response.msg, {title: "Remove Role From Channel"}).then(() => {
+        customPrompts.showAlert(response.msg, {title: "Remove Role From Channel"}).then(() => {
             window.location.reload();
         });
     });
@@ -138,18 +138,18 @@ function addRole() {
 
             if (roleId != 0) {
                 if (String(roleId).length != 4) {
-                    DialogManager.alert("The role id (4 character long number) you've entered is incorrect.", {title: "Invalid Role ID"});
+                    customPrompts.showAlert("The role id (4 character long number) you've entered is incorrect.", {title: "Invalid Role ID"});
                     return;
                 }
             }
             if (isNaN(roleId) == true) {
-                DialogManager.alert("The role id has to be a number", {title: "Invalid Role ID"});
+                customPrompts.showAlert("The role id has to be a number", {title: "Invalid Role ID"});
                 return;
             }
 
 
             socket.emit("addRoleToChannel", { id: UserManager.getID(), token: UserManager.getToken(), role: roleId, channel: currentChannelId }, function (response) {
-                DialogManager.alert(response.msg, {title: "Add Role To Channel"}).then(() => {
+                customPrompts.showAlert(response.msg, {title: "Add Role To Channel"}).then(() => {
                     window.location.reload();
                 });
             });
@@ -190,7 +190,7 @@ function savePermissions() {
     console.log(editChannel.permissions);
 
     socket.emit("saveChannelPermissions", { id: UserManager.getID(), token: UserManager.getToken(), channel: currentChannelId, role: currentRoleId, permission: editChannel.permissions[currentRoleId] }, function (response) {
-        DialogManager.alert(response.msg, {title: "Save Channel Permissions"});
+        customPrompts.showAlert(response.msg, {title: "Save Channel Permissions"});
         console.log(response)
         //window.location.reload();
     });

--- a/public/settings/channel/page/channel-permissions/channel-permissions.js
+++ b/public/settings/channel/page/channel-permissions/channel-permissions.js
@@ -122,8 +122,9 @@ function removeRole() {
     console.log(currentRoleId);
 
     socket.emit("removeRoleFromChannel", { id: UserManager.getID(), token: UserManager.getToken(), role: currentRoleId, channel: currentChannelId }, function (response) {
-        alert(response.msg);
-        window.location.reload();
+        DialogManager.alert(response.msg, {title: "Remove Role From Channel"}).then(() => {
+            window.location.reload();
+        });
     });
 }
 
@@ -137,19 +138,20 @@ function addRole() {
 
             if (roleId != 0) {
                 if (String(roleId).length != 4) {
-                    alert("The role id (4 character long number) you've entered is incorrect.");
+                    DialogManager.alert("The role id (4 character long number) you've entered is incorrect.", {title: "Invalid Role ID"});
                     return;
                 }
             }
             if (isNaN(roleId) == true) {
-                alert("The role id has to be a number");
+                DialogManager.alert("The role id has to be a number", {title: "Invalid Role ID"});
                 return;
             }
 
 
             socket.emit("addRoleToChannel", { id: UserManager.getID(), token: UserManager.getToken(), role: roleId, channel: currentChannelId }, function (response) {
-                alert(response.msg);
-                window.location.reload();
+                DialogManager.alert(response.msg, {title: "Add Role To Channel"}).then(() => {
+                    window.location.reload();
+                });
             });
         });
     });
@@ -188,7 +190,7 @@ function savePermissions() {
     console.log(editChannel.permissions);
 
     socket.emit("saveChannelPermissions", { id: UserManager.getID(), token: UserManager.getToken(), channel: currentChannelId, role: currentRoleId, permission: editChannel.permissions[currentRoleId] }, function (response) {
-        alert(response.msg);
+        DialogManager.alert(response.msg, {title: "Save Channel Permissions"});
         console.log(response)
         //window.location.reload();
     });

--- a/public/settings/group/page/group-info/group-info.js
+++ b/public/settings/group/page/group-info/group-info.js
@@ -20,7 +20,7 @@ function initGroupSettings(){
             console.log("Unable to get Group Information");
             console.log(err);
 
-            DialogManager.alert("Unable to get channel info. Please try to reload slowly until it works. Known bug!", {title: "Group Info Error"});
+            customPrompts.showAlert("Unable to get channel info. Please try to reload slowly until it works. Known bug!", {title: "Group Info Error"});
         }
 
     });
@@ -46,4 +46,3 @@ function showChannelSettings(response) {
         )
     );
 }
-

--- a/public/settings/group/page/group-info/group-info.js
+++ b/public/settings/group/page/group-info/group-info.js
@@ -20,7 +20,7 @@ function initGroupSettings(){
             console.log("Unable to get Group Information");
             console.log(err);
 
-            alert("Unable to get channel info. Please try to reload slowly until it works. Known bug!");
+            DialogManager.alert("Unable to get channel info. Please try to reload slowly until it works. Known bug!", {title: "Group Info Error"});
         }
 
     });
@@ -46,5 +46,4 @@ function showChannelSettings(response) {
         )
     );
 }
-
 

--- a/public/settings/group/page/group-permissions/group-permissions.js
+++ b/public/settings/group/page/group-permissions/group-permissions.js
@@ -110,12 +110,12 @@ function addRole() {
 
             if (roleId != 0) {
                 if (String(roleId).length != 4) {
-                    alert("The role id (4 character long number) you've entered is incorrect.");
+                    DialogManager.alert("The role id (4 character long number) you've entered is incorrect.", {title: "Invalid Role ID"});
                     return;
                 }
             }
             if (isNaN(roleId) == true) {
-                alert("The role id has to be a number");
+                DialogManager.alert("The role id has to be a number", {title: "Invalid Role ID"});
                 return;
             }
 

--- a/public/settings/group/page/group-permissions/group-permissions.js
+++ b/public/settings/group/page/group-permissions/group-permissions.js
@@ -110,12 +110,12 @@ function addRole() {
 
             if (roleId != 0) {
                 if (String(roleId).length != 4) {
-                    DialogManager.alert("The role id (4 character long number) you've entered is incorrect.", {title: "Invalid Role ID"});
+                    customPrompts.showAlert("The role id (4 character long number) you've entered is incorrect.", {title: "Invalid Role ID"});
                     return;
                 }
             }
             if (isNaN(roleId) == true) {
-                DialogManager.alert("The role id has to be a number", {title: "Invalid Role ID"});
+                customPrompts.showAlert("The role id has to be a number", {title: "Invalid Role ID"});
                 return;
             }
 

--- a/public/settings/server/page/banlist/banlist.js
+++ b/public/settings/server/page/banlist/banlist.js
@@ -41,25 +41,28 @@ function unbanUser(id) {
     var container = document.querySelector(`tr[data-member-id="${id}"]`);
     var username = container.querySelector(`#username[data-member-id="${id}"]`)?.innerText?.split(" ")[0];
 
-    if (!confirm("Do you want to unban the user " + username + "?")){
-        notify("Canceled unban", "info")
-        return;
-    }
-
-
-    socket.emit("unbanUser", {id: UserManager.getID(), token: UserManager.getToken(), target: id}, function (response) {
-        //notify("User was banned by " + response.data.name, "info", null, "normal");
-        if(response.type === "success"){
-            notify(response.msg, "success");
-            container.remove();
+    DialogManager.confirm("Do you want to unban the user " + username + "?", {
+        title: "Unban User",
+        confirmText: "Unban",
+        confirmColor: "error",
+    }).then((confirmed) => {
+        if (!confirmed){
+            notify("Canceled unban", "info")
+            return;
         }
-        else{
-            notify(response.msg, "error");
-            console.log(response.data)
-        }
+
+        socket.emit("unbanUser", {id: UserManager.getID(), token: UserManager.getToken(), target: id}, function (response) {
+            //notify("User was banned by " + response.data.name, "info", null, "normal");
+            if(response.type === "success"){
+                notify(response.msg, "success");
+                container.remove();
+            }
+            else{
+                notify(response.msg, "error");
+                console.log(response.data)
+            }
+        });
     });
-
-
 }
 
 function getBans() {
@@ -134,7 +137,7 @@ function getBans() {
                 // Add it to the html
                 emojiContainer.insertAdjacentHTML("beforeend", table);
             } else {
-                alert(response1?.error || response1?.msg);
+                DialogManager.alert(response1?.error || response1?.msg, {title: "Ban List"});
             }
         } catch (ex) {
             console.log(ex);

--- a/public/settings/server/page/banlist/banlist.js
+++ b/public/settings/server/page/banlist/banlist.js
@@ -41,7 +41,7 @@ function unbanUser(id) {
     var container = document.querySelector(`tr[data-member-id="${id}"]`);
     var username = container.querySelector(`#username[data-member-id="${id}"]`)?.innerText?.split(" ")[0];
 
-    DialogManager.confirm("Do you want to unban the user " + username + "?", {
+    customPrompts.showConfirmPrompt("Do you want to unban the user " + username + "?", {
         title: "Unban User",
         confirmText: "Unban",
         confirmColor: "error",
@@ -137,7 +137,7 @@ function getBans() {
                 // Add it to the html
                 emojiContainer.insertAdjacentHTML("beforeend", table);
             } else {
-                DialogManager.alert(response1?.error || response1?.msg, {title: "Ban List"});
+                customPrompts.showAlert(response1?.error || response1?.msg, {title: "Ban List"});
             }
         } catch (ex) {
             console.log(ex);

--- a/public/settings/server/page/file-uploads/file-uploads.html
+++ b/public/settings/server/page/file-uploads/file-uploads.html
@@ -31,13 +31,13 @@
         <div class="profile_input_container">
             <label>Cloudflare Image API Token</label><br>
             <input type="password" id="cfAccountToken" style="background-color: #36393F;" oninput="updatePreview('cfAccountToken');">
-            <label style="font-style: italic; margin-left: 4px;" onclick="DialogManager.alert(document.getElementById('cfAccountToken').value, { title: 'Cloudflare Image API Token' });">(Show)</label>
+            <label style="font-style: italic; margin-left: 4px;" onclick="customPrompts.showAlert(document.getElementById('cfAccountToken').value, { title: 'Cloudflare Image API Token' });">(Show)</label>
         </div>
 
         <div class="profile_input_container">
             <label>Cloudflare Image Account Hash</label><br>
             <input type="password" id="cfAccountHash" style="background-color: #36393F;" oninput="updatePreview('cfAccountHash');">
-            <label style="font-style: italic; margin-left: 4px;" onclick="DialogManager.alert(document.getElementById('cfAccountHash').value, { title: 'Cloudflare Image Account Hash' });">(Show)</label>
+            <label style="font-style: italic; margin-left: 4px;" onclick="customPrompts.showAlert(document.getElementById('cfAccountHash').value, { title: 'Cloudflare Image Account Hash' });">(Show)</label>
         </div>
 
         Please never share the API Token and Account Hash. They are hidden for a reason!

--- a/public/settings/server/page/file-uploads/file-uploads.html
+++ b/public/settings/server/page/file-uploads/file-uploads.html
@@ -31,13 +31,13 @@
         <div class="profile_input_container">
             <label>Cloudflare Image API Token</label><br>
             <input type="password" id="cfAccountToken" style="background-color: #36393F;" oninput="updatePreview('cfAccountToken');">
-            <label style="font-style: italic; margin-left: 4px;" onclick="alert(document.getElementById('cfAccountToken').value);">(Show)</label>
+            <label style="font-style: italic; margin-left: 4px;" onclick="DialogManager.alert(document.getElementById('cfAccountToken').value, { title: 'Cloudflare Image API Token' });">(Show)</label>
         </div>
 
         <div class="profile_input_container">
             <label>Cloudflare Image Account Hash</label><br>
             <input type="password" id="cfAccountHash" style="background-color: #36393F;" oninput="updatePreview('cfAccountHash');">
-            <label style="font-style: italic; margin-left: 4px;" onclick="alert(document.getElementById('cfAccountHash').value);">(Show)</label>
+            <label style="font-style: italic; margin-left: 4px;" onclick="DialogManager.alert(document.getElementById('cfAccountHash').value, { title: 'Cloudflare Image Account Hash' });">(Show)</label>
         </div>
 
         Please never share the API Token and Account Hash. They are hidden for a reason!

--- a/public/settings/server/page/file-uploads/file-uploads.js
+++ b/public/settings/server/page/file-uploads/file-uploads.js
@@ -108,13 +108,12 @@ function saveSettings(){
                                         cloudflareHash: setting_cfAccountHash.value,
                                         maxLocalUpload: setting_localFsLimit.value
         }, function (response) {
-
-            alert(response.msg);
+            DialogManager.alert(response.msg, {title: "Media Settings"});
             console.log(response);
         });
     }
     catch(error){
-        alert("Error while trying to save settings: " + error);
+        DialogManager.alert("Error while trying to save settings: " + error, {title: "Media Settings Error"});
         return;
     }
 }

--- a/public/settings/server/page/file-uploads/file-uploads.js
+++ b/public/settings/server/page/file-uploads/file-uploads.js
@@ -108,12 +108,12 @@ function saveSettings(){
                                         cloudflareHash: setting_cfAccountHash.value,
                                         maxLocalUpload: setting_localFsLimit.value
         }, function (response) {
-            DialogManager.alert(response.msg, {title: "Media Settings"});
+            customPrompts.showAlert(response.msg, {title: "Media Settings"});
             console.log(response);
         });
     }
     catch(error){
-        DialogManager.alert("Error while trying to save settings: " + error, {title: "Media Settings Error"});
+        customPrompts.showAlert("Error while trying to save settings: " + error, {title: "Media Settings Error"});
         return;
     }
 }

--- a/public/settings/server/page/roles/roles.js
+++ b/public/settings/server/page/roles/roles.js
@@ -113,7 +113,7 @@ function saveAppearance() {
         roleId: currentRoleId,
         data: serverRoleResponse[currentRoleId]
     }, function (response) {
-        DialogManager.alert(response.msg, {title: "Role Appearance"}).then(() => {
+        customPrompts.showAlert(response.msg, {title: "Role Appearance"}).then(() => {
             window.location.reload();
         });
     });
@@ -164,7 +164,7 @@ function saveSorting() {
         token: UserManager.getToken(),
         sorted: sortArray
     }, function (response) {
-        DialogManager.alert(response.msg, {title: "Role Hierarchy"}).then(() => {
+        customPrompts.showAlert(response.msg, {title: "Role Hierarchy"}).then(() => {
             window.location.reload();
         });
     });
@@ -178,7 +178,7 @@ function removeFromRole(roleId, userId) {
         role: roleId,
         target: userId
     }, function (response) {
-        DialogManager.alert(response.msg, {title: "Remove User From Role"}).then(() => {
+        customPrompts.showAlert(response.msg, {title: "Remove User From Role"}).then(() => {
             window.location.reload();
         });
     });
@@ -196,14 +196,14 @@ function savePermissions() {
         role: currentRoleId,
         permissions: editedServerRoleResponse[currentRoleId].permissions
     }, function (response) {
-        DialogManager.alert(response.msg, {title: "Save Role Permissions"}).then(() => {
+        customPrompts.showAlert(response.msg, {title: "Save Role Permissions"}).then(() => {
             window.location.reload();
         });
     });
 }
 
 function addToRole() {
-    DialogManager.prompt({
+    customPrompts.showInput({
         title: "Add User to Role",
         label: "User ID",
         placeholder: "Enter the 12-digit user id",
@@ -215,7 +215,7 @@ function addToRole() {
         if (!trimmedUserId) return;
 
         if (trimmedUserId.length != 12 || isNaN(trimmedUserId) == true) {
-            DialogManager.alert("The user id (12 character long number) you've entered is incorrect.", {title: "Invalid User ID"});
+            customPrompts.showAlert("The user id (12 character long number) you've entered is incorrect.", {title: "Invalid User ID"});
             return;
         }
 
@@ -225,7 +225,7 @@ function addToRole() {
             role: currentRoleId,
             target: trimmedUserId
         }, function (response) {
-            DialogManager.alert(response.msg, {title: "Add User to Role"}).then(() => {
+            customPrompts.showAlert(response.msg, {title: "Add User to Role"}).then(() => {
                 window.location.reload();
             });
         });
@@ -235,7 +235,7 @@ function addToRole() {
 function createRole() {
     console.log(socket.connected)
     socket.emit("createRole", {id: UserManager.getID(), token: UserManager.getToken()}, function (response) {
-        DialogManager.alert(response.msg, {title: "Create Role"}).then(() => {
+        customPrompts.showAlert(response.msg, {title: "Create Role"}).then(() => {
             window.location.reload();
         });
     });
@@ -275,7 +275,7 @@ function deleteRole() {
         token: UserManager.getToken(),
         roleId: currentRoleId
     }, function (response) {
-        DialogManager.alert(response.msg, {title: "Delete Role"}).then(() => {
+        customPrompts.showAlert(response.msg, {title: "Delete Role"}).then(() => {
             window.location.reload();
         });
     });

--- a/public/settings/server/page/roles/roles.js
+++ b/public/settings/server/page/roles/roles.js
@@ -113,8 +113,9 @@ function saveAppearance() {
         roleId: currentRoleId,
         data: serverRoleResponse[currentRoleId]
     }, function (response) {
-        alert(response.msg);
-        window.location.reload();
+        DialogManager.alert(response.msg, {title: "Role Appearance"}).then(() => {
+            window.location.reload();
+        });
     });
 }
 
@@ -163,9 +164,9 @@ function saveSorting() {
         token: UserManager.getToken(),
         sorted: sortArray
     }, function (response) {
-
-        alert(response.msg);
-        window.location.reload();
+        DialogManager.alert(response.msg, {title: "Role Hierarchy"}).then(() => {
+            window.location.reload();
+        });
     });
 }
 
@@ -177,8 +178,9 @@ function removeFromRole(roleId, userId) {
         role: roleId,
         target: userId
     }, function (response) {
-        alert(response.msg);
-        window.location.reload();
+        DialogManager.alert(response.msg, {title: "Remove User From Role"}).then(() => {
+            window.location.reload();
+        });
     });
 }
 
@@ -194,36 +196,48 @@ function savePermissions() {
         role: currentRoleId,
         permissions: editedServerRoleResponse[currentRoleId].permissions
     }, function (response) {
-        alert(response.msg);
-        window.location.reload();
+        DialogManager.alert(response.msg, {title: "Save Role Permissions"}).then(() => {
+            window.location.reload();
+        });
     });
 }
 
 function addToRole() {
+    DialogManager.prompt({
+        title: "Add User to Role",
+        label: "User ID",
+        placeholder: "Enter the 12-digit user id",
+        submitText: "Add",
+        submitColor: "success",
+        minWidth: 340,
+    }).then((userId) => {
+        const trimmedUserId = userId?.trim();
+        if (!trimmedUserId) return;
 
-    var userId = prompt("Please enter the user id of the account you want to add");
+        if (trimmedUserId.length != 12 || isNaN(trimmedUserId) == true) {
+            DialogManager.alert("The user id (12 character long number) you've entered is incorrect.", {title: "Invalid User ID"});
+            return;
+        }
 
-    if (userId.length != 12 || isNaN(userId) == true) {
-        alert("The user id (12 character long number) you've entered is incorrect.");
-        return;
-    }
-
-    socket.emit("addUserToRole", {
-        id: UserManager.getID(),
-        token: UserManager.getToken(),
-        role: currentRoleId,
-        target: userId
-    }, function (response) {
-        alert(response.msg);
-        window.location.reload();
+        socket.emit("addUserToRole", {
+            id: UserManager.getID(),
+            token: UserManager.getToken(),
+            role: currentRoleId,
+            target: trimmedUserId
+        }, function (response) {
+            DialogManager.alert(response.msg, {title: "Add User to Role"}).then(() => {
+                window.location.reload();
+            });
+        });
     });
 }
 
 function createRole() {
     console.log(socket.connected)
     socket.emit("createRole", {id: UserManager.getID(), token: UserManager.getToken()}, function (response) {
-        alert(response.msg);
-        window.location.reload();
+        DialogManager.alert(response.msg, {title: "Create Role"}).then(() => {
+            window.location.reload();
+        });
     });
 }
 
@@ -261,8 +275,9 @@ function deleteRole() {
         token: UserManager.getToken(),
         roleId: currentRoleId
     }, function (response) {
-        alert(response.msg);
-        window.location.reload();
+        DialogManager.alert(response.msg, {title: "Delete Role"}).then(() => {
+            window.location.reload();
+        });
     });
 }
 

--- a/public/settings/server/page/whats-new/whats-new.html
+++ b/public/settings/server/page/whats-new/whats-new.html
@@ -756,7 +756,7 @@
                             Proper Notification Boxes have been implemented. No (or less) ugly alert boxes! Whats a
                             alert box?
                             <font style="text-decoration: underline; cursor: pointer;"
-                                onclick="customPrompts.showAlert('This is a alert box!', { title: 'Alert Example' });">click here to find out!</font>
+                                onclick="alert('This is a alert box!');">click here to find out!</font>
                             <font style="text-decoration: underline; cursor: pointer;"
                                 onclick="notify('Looks better right?!', 'success');">And this is the new box!</font>
                         </li>
@@ -815,7 +815,7 @@
                             Proper Notification Boxes have been implemented. No (or less) ugly alert boxes! Whats a
                             alert box?
                             <font style="text-decoration: underline; cursor: pointer;"
-                                onclick="customPrompts.showAlert('This is a alert box!', { title: 'Alert Example' });">click here to find out!</font>
+                                onclick="alert('This is a alert box!');">click here to find out!</font>
                             <font style="text-decoration: underline; cursor: pointer;"
                                 onclick="notify('Looks better right?!', 'success');">And this is the new box!</font>
                         </li>

--- a/public/settings/server/page/whats-new/whats-new.html
+++ b/public/settings/server/page/whats-new/whats-new.html
@@ -756,7 +756,7 @@
                             Proper Notification Boxes have been implemented. No (or less) ugly alert boxes! Whats a
                             alert box?
                             <font style="text-decoration: underline; cursor: pointer;"
-                                onclick="alert('This is a alert box!');">click here to find out!</font>
+                                onclick="customPrompts.showAlert('This is a alert box!', { title: 'Alert Example' });">click here to find out!</font>
                             <font style="text-decoration: underline; cursor: pointer;"
                                 onclick="notify('Looks better right?!', 'success');">And this is the new box!</font>
                         </li>
@@ -815,7 +815,7 @@
                             Proper Notification Boxes have been implemented. No (or less) ugly alert boxes! Whats a
                             alert box?
                             <font style="text-decoration: underline; cursor: pointer;"
-                                onclick="alert('This is a alert box!');">click here to find out!</font>
+                                onclick="customPrompts.showAlert('This is a alert box!', { title: 'Alert Example' });">click here to find out!</font>
                             <font style="text-decoration: underline; cursor: pointer;"
                                 onclick="notify('Looks better right?!', 'success');">And this is the new box!</font>
                         </li>


### PR DESCRIPTION
## Summary

Follow-up to #119.

This replaces the remaining live native browser `prompt()`, `confirm()`, and `alert()` usage on the `dev` branch with the app's custom prompt modal flow.

## What Changed

- added Promise-based dialog helpers on top of `Prompt` in `public/js/prompts.js`
- replaced remaining live native dialogs in:
  - `public/chat.js`
  - `public/js/core/UserManager.js`
  - `public/js/core/RichEditor.js`
  - `public/js/channels/channels.js`
  - `public/settings/server/page/roles/roles.js`
  - `public/settings/server/page/banlist/banlist.js`
  - `public/settings/server/page/file-uploads/file-uploads.{js,html}`
  - `public/settings/group/page/group-info/group-info.js`
  - `public/settings/channel/page/channel-info/channel-info.js`
  - `public/settings/group/page/group-permissions/group-permissions.js`
  - `public/settings/channel/page/channel-permissions/channel-permissions.js`
  - `public/settings/account/page/profile/profile.js`

## Why

The earlier fix for #119 addressed `createGroup()`, but other desktop-facing flows on `dev` still depended on native browser dialogs. Those can fail or behave inconsistently in the Linux desktop client, so this change moves the remaining live dialog flows onto the same custom prompt system already used across the app.

## Notes

- This PR is scoped to files that exist on `dev`.
- I intentionally did not touch vendored `public/js/quill.js` or static example content such as `whats-new.html`.

## Validation

- repo-wide search confirmed the remaining native dialog usage on `dev` is limited to the new dialog helper API, comments, vendored code, or static example content
- syntax-checked all touched JavaScript files with `new Function(...)`

Follow-up to #119
