### PR TITLE
Fix create channel validation and error handling

### DIFF
--- a/modules/sockets/createChannel.mjs
+++ b/modules/sockets/createChannel.mjs
@@ -8,18 +8,47 @@ export default (io) => (socket) => {
     socket.on('createChannel', async function (member, response) {
         if (await validateMemberId(member?.id, socket, member?.token) === true
         ) {
+            member.id = xssFilters.inHTMLData(member.id)
+            member.token = xssFilters.inHTMLData(member.token)
+            member.group = xssFilters.inHTMLData(member.group)
+            member.category = xssFilters.inHTMLData(member.category)
+            member.value = xssFilters.inHTMLData(member.value)
+            member.type = xssFilters.inHTMLData(member.type)
 
             if (!await hasPermission(member.id, "manageChannels")) {
                 response({ msg: "You are not allowed to create a channel", type: "error", error: "Missing permissions to create channel" })
                 return;
             }
 
+            const group = serverconfig.groups?.[member.group];
+            if (!group) {
+                response({ msg: "Couldnt create channel", type: "error", error: "Invalid group" })
+                return;
+            }
+
+            const category = group.channels?.categories?.[member.category];
+            if (!category) {
+                response({ msg: "Couldnt create channel", type: "error", error: "Invalid category" })
+                return;
+            }
+
+            const channelName = escapeHtml(String(member.value || "").trim());
+            if (!channelName) {
+                response({ msg: "Channel name is required", type: "error", error: "Missing channel name" })
+                return;
+            }
+
+            if (!["text", "voice"].includes(member.type)) {
+                response({ msg: "Invalid channel type", type: "error", error: "Invalid channel type" })
+                return;
+            }
+
             try {
                 var channelId = generateId(4);
 
-                serverconfig.groups[member.group].channels.categories[member.category].channel[channelId] = {
+                category.channel[channelId] = {
                     id: channelId,
-                    name: xssFilters.inHTMLData(escapeHtml(member.value)),
+                    name: channelName,
                     type: member.type,
                     description: "Default Channel Description",
                     sortId: 0,
@@ -40,6 +69,7 @@ export default (io) => (socket) => {
             catch (e) {
                 Logger.error("Couldnt create channel");
                 Logger.error(e);
+                response({ msg: "Couldnt create channel", type: "error", error: "Unexpected error creating channel" })
             }
         }
     });

--- a/modules/sockets/createChannel.mjs
+++ b/modules/sockets/createChannel.mjs
@@ -1,47 +1,33 @@
-import { saveConfig, serverconfig, xssFilters } from "../../index.mjs";
+import { saveConfig, serverconfig } from "../../index.mjs";
 import { getChannelTree, hasPermission } from "../functions/chat/main.mjs";
 import Logger from "../functions/logger.mjs";
-import { copyObject, escapeHtml, generateId, sendMessageToUser, validateMemberId } from "../functions/main.mjs";
+import { generateId, validateMemberId } from "../functions/main.mjs";
+import { stripHTML } from "../functions/sanitizing/functions.mjs";
 
 export default (io) => (socket) => {
     // socket.on code here
     socket.on('createChannel', async function (member, response) {
         if (await validateMemberId(member?.id, socket, member?.token) === true
         ) {
-            member.id = xssFilters.inHTMLData(member.id)
-            member.token = xssFilters.inHTMLData(member.token)
-            member.group = xssFilters.inHTMLData(member.group)
-            member.category = xssFilters.inHTMLData(member.category)
-            member.value = xssFilters.inHTMLData(member.value)
-            member.type = xssFilters.inHTMLData(member.type)
+            member.id = stripHTML(member?.id)?.trim()
+            member.token = stripHTML(member?.token)?.trim()
+            member.group = stripHTML(member?.group)?.trim()
+            member.category = stripHTML(member?.category)?.trim()
+            member.value = stripHTML(member?.value)?.trim()
+            member.type = stripHTML(member?.type)?.trim()
 
-            if (!await hasPermission(member.id, "manageChannels")) {
-                response({ msg: "You are not allowed to create a channel", type: "error", error: "Missing permissions to create channel" })
-                return;
-            }
+            if (!await hasPermission(member.id, "manageChannels")) return response({ error: "Missing permissions to create channel" })
 
             const group = serverconfig.groups?.[member.group];
-            if (!group) {
-                response({ msg: "Couldnt create channel", type: "error", error: "Invalid group" })
-                return;
-            }
+            if (!group) return response({ error: "Couldnt create channel: invalid group" })
 
             const category = group.channels?.categories?.[member.category];
-            if (!category) {
-                response({ msg: "Couldnt create channel", type: "error", error: "Invalid category" })
-                return;
-            }
+            if (!category) return response({ error: "Couldnt create channel: missing category" })
 
-            const channelName = escapeHtml(String(member.value || "").trim());
-            if (!channelName) {
-                response({ msg: "Channel name is required", type: "error", error: "Missing channel name" })
-                return;
-            }
+            const channelName = stripHTML(member.value);
+            if (!channelName) return response({ error: "Couldnt create channel: missing channel name" })
 
-            if (!["text", "voice"].includes(member.type)) {
-                response({ msg: "Invalid channel type", type: "error", error: "Invalid channel type" })
-                return;
-            }
+            if (!["text", "voice"].includes(member.type)) return response({ error: "Couldnt create channel: invalid channel type" })
 
             try {
                 var channelId = generateId(4);
@@ -64,12 +50,12 @@ export default (io) => (socket) => {
 
                 saveConfig(serverconfig);
                 io.emit("receiveChannelTree", getChannelTree(member));
-                response({ msg: "Channel created successfully", type: "success" })
+                response({ error: null })
             }
             catch (e) {
                 Logger.error("Couldnt create channel");
                 Logger.error(e);
-                response({ msg: "Couldnt create channel", type: "error", error: "Unexpected error creating channel" })
+                response({ error: "Couldnt create channel: unexpected error" })
             }
         }
     });

--- a/public/js/core/AdminActions.js
+++ b/public/js/core/AdminActions.js
@@ -229,6 +229,20 @@ class AdminActions {
 
 
     static createChannel(category) {
+        const normalizedCategory = String(category || "").replace("category-", "").trim();
+
+        if (!normalizedCategory) {
+            showSystemMessage({
+                title: "Couldnt create channel",
+                text: "No category was selected.",
+                icon: "error",
+                img: null,
+                type: "error",
+                duration: 2000
+            });
+            return;
+        }
+
         customPrompts.showPrompt(
             "Create a channel",
             `
@@ -249,13 +263,40 @@ class AdminActions {
         </div>
         `,
             (values) => {
+                const channelName = String(values.channelName || "").trim();
+                const channelType = values.selected;
+
+                if (!channelName) {
+                    showSystemMessage({
+                        title: "Channel name required",
+                        text: "",
+                        icon: "error",
+                        img: null,
+                        type: "error",
+                        duration: 1500
+                    });
+                    return false;
+                }
+
+                if (!["text", "voice"].includes(channelType)) {
+                    showSystemMessage({
+                        title: "Channel type required",
+                        text: "",
+                        icon: "error",
+                        img: null,
+                        type: "error",
+                        duration: 1500
+                    });
+                    return false;
+                }
+
                 socket.emit("createChannel", {
                     id: UserManager.getID(),
-                    value: values.channelName,
-                    type: values.selected,
+                    value: channelName,
+                    type: channelType,
                     token: UserManager.getToken(),
                     group: UserManager.getGroup().replace("group-", ""),
-                    category: category.replace("category-", "")
+                    category: normalizedCategory
                 }, function (response) {
                     showSystemMessage({
                         title: response.msg,

--- a/public/js/core/AdminActions.js
+++ b/public/js/core/AdminActions.js
@@ -298,12 +298,13 @@ class AdminActions {
                     group: UserManager.getGroup().replace("group-", ""),
                     category: normalizedCategory
                 }, function (response) {
+                    const isError = Boolean(response?.error);
                     showSystemMessage({
-                        title: response.msg,
+                        title: isError ? response.error : "Channel created successfully",
                         text: "",
-                        icon: response.type,
+                        icon: isError ? "error" : "success",
                         img: null,
-                        type: response.type,
+                        type: isError ? "error" : "success",
                         duration: 1000
                     });
                 });

--- a/public/js/prompts.js
+++ b/public/js/prompts.js
@@ -446,10 +446,13 @@ class Prompt {
             }
         });
 
+        const callbackResult = this.currentCallback ? this.currentCallback(values) : undefined;
+
         if (this.currentCallback) {
-            this.currentCallback(values);
             this.currentCallback = null;
         }
+
+        if (callbackResult === false) return;
 
         if (this.afterSubmitAction) {
             this.afterSubmitAction({ canceled: false, values });

--- a/public/serverlist/js/libs/prompts/prompts.js
+++ b/public/serverlist/js/libs/prompts/prompts.js
@@ -446,10 +446,13 @@ class Prompt {
             }
         });
 
+        const callbackResult = this.currentCallback ? this.currentCallback(values) : undefined;
+
         if (this.currentCallback) {
-            this.currentCallback(values);
             this.currentCallback = null;
         }
+
+        if (callbackResult === false) return;
 
         if (this.afterSubmitAction) {
             this.afterSubmitAction({ canceled: false, values });


### PR DESCRIPTION
## Summary

Fix the project draft item `Create channel bug` by hardening the create-channel flow on both the client and socket handler.

## What changed

- validate the selected category before opening the channel creation request
- require a non-empty channel name and a valid channel type before submitting
- keep the prompt open when validation fails so the user can correct the input immediately
- validate the incoming group, category, channel name, and channel type on the socket handler before mutating server config
- return explicit error responses instead of failing silently when channel creation receives bad data

## Why

The previous flow would accept incomplete or invalid create-channel input and then rely on the server handler to index directly into the config tree. If the category was stale, the name was empty, or the channel type was missing, channel creation could fail silently or create malformed channel data.

## Validation

- `node --check public/js/core/AdminActions.js`
- `node --check modules/sockets/createChannel.mjs`
- `node --check public/js/prompts.js`
- `node --check public/serverlist/js/libs/prompts/prompts.js`
