### PR TITLE
Persist screenshare stream settings

### DIFF
--- a/public/js/core/voip.js
+++ b/public/js/core/voip.js
@@ -1,5 +1,6 @@
 class VoIP {
     constructor(livekitUrl = "", applicationServerUrl = "") {
+        this.SCREENSHARE_SETTINGS_KEY = "vc_screenshare_settings";
         this.APPLICATION_SERVER_URL = applicationServerUrl;
         this.LIVEKIT_URL = livekitUrl;
         this.room = null;
@@ -9,6 +10,7 @@ class VoIP {
             frameRate: 60,
             maxBitrate: 50_000_000,
         };
+        this.loadStreamSettings();
 
         this.onJoin = null;
         this.onLeave = null;
@@ -33,6 +35,38 @@ class VoIP {
         this._audioNodes = new Map();
         this._mediaElSources = new WeakMap();
         this._volumes = new Map();
+    }
+
+    loadStreamSettings() {
+        try {
+            const rawSettings = localStorage.getItem(this.SCREENSHARE_SETTINGS_KEY);
+            if (!rawSettings) return;
+
+            const savedSettings = JSON.parse(rawSettings);
+            if (!savedSettings || typeof savedSettings !== "object") return;
+
+            if (typeof savedSettings.resolution === "string" && savedSettings.resolution.length > 0) {
+                this.streamSettings.resolution = savedSettings.resolution;
+            }
+
+            if (Number.isFinite(Number(savedSettings.frameRate))) {
+                this.streamSettings.frameRate = Number(savedSettings.frameRate);
+            }
+
+            if (Number.isFinite(Number(savedSettings.maxBitrate))) {
+                this.streamSettings.maxBitrate = Number(savedSettings.maxBitrate);
+            }
+        } catch (error) {
+            console.warn("Unable to load saved screenshare settings", error);
+        }
+    }
+
+    saveStreamSettings() {
+        try {
+            localStorage.setItem(this.SCREENSHARE_SETTINGS_KEY, JSON.stringify(this.streamSettings));
+        } catch (error) {
+            console.warn("Unable to save screenshare settings", error);
+        }
     }
 
     cleanupAudioElById(audioId, memberId, isScreen) {
@@ -419,6 +453,11 @@ class VoIP {
         if (resolution) this.streamSettings.resolution = resolution;
         if (frameRate) this.streamSettings.frameRate = frameRate;
         if (maxBitrate) this.streamSettings.maxBitrate = maxBitrate;
+        this.saveStreamSettings();
+    }
+
+    getStreamSettings() {
+        return {...this.streamSettings};
     }
 
     _cleanupDetachedEls(detachedEls){

--- a/public/js/vc-handler.js
+++ b/public/js/vc-handler.js
@@ -676,34 +676,36 @@ async function toggleScreenshare() {
         return;
     }
 
+    const currentStreamSettings = voip.getStreamSettings();
+
     customPrompts.showPrompt("Stream Settings", `
        <div style="margin:20px 0;">
             <div class="prompt-form-group">
                 <label class="prompt-label">Resolution</label>
                 <select id="res" class="prompt-select">
-                    <option value="1280x720">720p</option>
-                    <option value="1920x1080" selected>1080p</option>
-                    <option value="2560x1440">2K (1440p)</option>
-                    <option value="3840x2160">4K (2160p)</option>
+                    <option value="1280x720" ${currentStreamSettings.resolution === "1280x720" ? "selected" : ""}>720p</option>
+                    <option value="1920x1080" ${currentStreamSettings.resolution === "1920x1080" ? "selected" : ""}>1080p</option>
+                    <option value="2560x1440" ${currentStreamSettings.resolution === "2560x1440" ? "selected" : ""}>2K (1440p)</option>
+                    <option value="3840x2160" ${currentStreamSettings.resolution === "3840x2160" ? "selected" : ""}>4K (2160p)</option>
                 </select>
             </div>
             <div class="prompt-form-group">
                 <label class="prompt-label">FPS</label>
                 <select id="fps" class="prompt-select">
-                    <option value="30">30</option>
-                    <option value="60" selected>60</option>
-                    <option value="120">120</option>
+                    <option value="30" ${currentStreamSettings.frameRate === 30 ? "selected" : ""}>30</option>
+                    <option value="60" ${currentStreamSettings.frameRate === 60 ? "selected" : ""}>60</option>
+                    <option value="120" ${currentStreamSettings.frameRate === 120 ? "selected" : ""}>120</option>
                 </select>
             </div>
             <div class="prompt-form-group">
                 <label class="prompt-label">Bitrate</label>
                 <select id="bit" class="prompt-select">
-                    <option value="3000000">3 Mbit</option>
-                    <option value="8000000" selected>8 Mbit</option>
-                    <option value="12000000">12 Mbit</option>
-                    <option value="20000000">20 Mbit</option>
-                    <option value="35000000">35 Mbit</option>
-                    <option value="50000000">50 Mbit</option>
+                    <option value="3000000" ${currentStreamSettings.maxBitrate === 3000000 ? "selected" : ""}>3 Mbit</option>
+                    <option value="8000000" ${currentStreamSettings.maxBitrate === 8000000 ? "selected" : ""}>8 Mbit</option>
+                    <option value="12000000" ${currentStreamSettings.maxBitrate === 12000000 ? "selected" : ""}>12 Mbit</option>
+                    <option value="20000000" ${currentStreamSettings.maxBitrate === 20000000 ? "selected" : ""}>20 Mbit</option>
+                    <option value="35000000" ${currentStreamSettings.maxBitrate === 35000000 ? "selected" : ""}>35 Mbit</option>
+                    <option value="50000000" ${currentStreamSettings.maxBitrate === 50000000 ? "selected" : ""}>50 Mbit</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- load saved screenshare resolution, FPS, and bitrate settings from local storage when voice initializes
- persist updated stream settings whenever the screenshare configuration changes
- preselect the saved values in the screenshare prompt instead of resetting to hard-coded defaults

## Validation

- node --check public/js/core/voip.js
- node --check public/js/vc-handler.js