### PR TITLE
Protect exported identity files with passwords

### DIFF
--- a/modules/sockets/exportAccount.mjs
+++ b/modules/sockets/exportAccount.mjs
@@ -1,7 +1,39 @@
-import { serverconfig, xssFilters } from "../../index.mjs";
-import { hasPermission } from "../functions/chat/main.mjs";
+import { pbkdf2Sync, randomBytes, createCipheriv } from "node:crypto";
+import { serverconfig } from "../../index.mjs";
 import Logger from "../functions/logger.mjs";
-import { copyObject, sendMessageToUser, validateMemberId } from "../functions/main.mjs";
+import { validateMemberId } from "../functions/main.mjs";
+
+function withAbsoluteAssetUrl(assetPath, origin) {
+    if (typeof assetPath !== "string") return assetPath;
+    if (!assetPath.startsWith("/") || !origin) return assetPath;
+    return `${origin}${assetPath}`;
+}
+
+function encryptExportedAccount(account, passphrase) {
+    const salt = randomBytes(16);
+    const iv = randomBytes(12);
+    const iterations = 250000;
+    const key = pbkdf2Sync(passphrase, salt, iterations, 32, "sha256");
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+
+    const ciphertext = Buffer.concat([
+        cipher.update(JSON.stringify(account), "utf8"),
+        cipher.final(),
+        cipher.getAuthTag()
+    ]);
+
+    return {
+        encrypted: true,
+        version: 1,
+        algorithm: "AES-GCM",
+        kdf: "PBKDF2",
+        hash: "SHA-256",
+        iterations,
+        salt: salt.toString("base64"),
+        iv: iv.toString("base64"),
+        ciphertext: ciphertext.toString("base64")
+    };
+}
 
 export default (io) => (socket) => {
     // socket.on code here
@@ -9,11 +41,22 @@ export default (io) => (socket) => {
         if (await validateMemberId(member?.id, socket, member?.token)
         ) {
             try{
-                // some funky code here
-                response({account: serverconfig?.servermembers[member?.id]})
+                const account = JSON.parse(JSON.stringify(serverconfig?.servermembers[member?.id] || {}));
+                const origin = typeof member?.origin === "string" ? member.origin : "";
+
+                account.icon = withAbsoluteAssetUrl(account.icon, origin);
+                account.banner = withAbsoluteAssetUrl(account.banner, origin);
+
+                if (typeof member?.passphrase === "string" && member.passphrase.length > 0) {
+                    response({ account: encryptExportedAccount(account, member.passphrase), encrypted: true, error: null });
+                    return;
+                }
+
+                response({ account, encrypted: false, error: null })
             }
             catch (exception){
                 Logger.error(exception);
+                response({ account: null, encrypted: false, error: "Unable to export account" });
             }
         }
 

--- a/public/js/core/Crypto.js
+++ b/public/js/core/Crypto.js
@@ -1,4 +1,57 @@
 class Crypto {
+    static arrayBufferToBase64(buffer) {
+        return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+    }
+
+    static base64ToUint8Array(value) {
+        const binaryString = atob(value);
+        return Uint8Array.from(binaryString, char => char.charCodeAt(0));
+    }
+
+    static async derivePassphraseKey(passphrase, saltBase64, iterations = 250000) {
+        const encoder = new TextEncoder();
+        const passphraseKey = await window.crypto.subtle.importKey(
+            "raw",
+            encoder.encode(passphrase),
+            "PBKDF2",
+            false,
+            ["deriveKey"]
+        );
+
+        return await window.crypto.subtle.deriveKey(
+            {
+                name: "PBKDF2",
+                salt: this.base64ToUint8Array(saltBase64),
+                iterations,
+                hash: "SHA-256"
+            },
+            passphraseKey,
+            {
+                name: "AES-GCM",
+                length: 256
+            },
+            false,
+            ["decrypt"]
+        );
+    }
+
+    static async decryptProtectedExport(payload, passphrase) {
+        if (!payload?.encrypted) return payload;
+        if (!passphrase) throw new Error("Missing password");
+
+        const key = await this.derivePassphraseKey(passphrase, payload.salt, payload.iterations);
+        const decryptedBuffer = await window.crypto.subtle.decrypt(
+            {
+                name: "AES-GCM",
+                iv: this.base64ToUint8Array(payload.iv)
+            },
+            key,
+            this.base64ToUint8Array(payload.ciphertext)
+        );
+
+        return JSON.parse(new TextDecoder().decode(decryptedBuffer));
+    }
+
     static async dSyncTest() {
         const result = await fetch("/dSyncAuth/login", {
             method: "POST",

--- a/public/settings/account/page/profile/profile.js
+++ b/public/settings/account/page/profile/profile.js
@@ -86,40 +86,97 @@ function setPreview() {
 }
 
 async function exportAccount() {
+    const runExport = (passphrase = "") => {
+        socket.emit("exportAccount", {
+            id: UserManager.getID(),
+            token: UserManager.getToken(),
+            origin: window.location.origin,
+            passphrase
+        }, async function (response) {
+            if (response?.error) {
+                showSystemMessage({
+                    title: "Unable to export account",
+                    text: response.error,
+                    icon: "error",
+                    img: null,
+                    type: "error",
+                    duration: 4000
+                });
+                return;
+            }
 
-    socket.emit("exportAccount", {id: UserManager.getID(), token: UserManager.getToken(),}, async function (response) {
-        console.log(response)
-
-        if (response.account.icon.substring(0, 1).includes("/")) {
-            response.account.icon = `${window.location.origin}${response.account.icon}`
-        }
-
-        if (response.account.banner.substring(0, 1).includes("/")) {
-            response.account.banner = `${window.location.origin}${response.account.banner}`
-        }
-
-        customPrompts.showConfirm("Generate a QR code?",
-            [["Yes", "success"], ["No", "error"]],
-            (selectedOption) => {
-                if (selectedOption === "yes") {
-                    let qrcodeElement = document.getElementById("export-account-qrcode");
-
-                    new QRCode(qrcodeElement, {
-                        text: JSON.stringify(UserManager.getShortenedAccountData(response.account)),
-                        correctLevel: QRCode.CorrectLevel.L,
-                        typeNumber: 40,
-                    })
-                }
-
-                customPrompts.showConfirm("Export as file?",
+            if (response?.encrypted === true) {
+                customPrompts.showConfirm("Export encrypted file?",
                     [["Yes", "success"], ["No", "error"]],
-                    async (selectedOption2) => {
-                        if (selectedOption2 === "yes") {
-                            await FileManager.saveFile(JSON.stringify(response.account), `${window.location.origin}_identity_${UserManager.getUsername()}.json`)
+                    async (selectedOption) => {
+                        if (selectedOption === "yes") {
+                            await FileManager.saveFile(JSON.stringify(response.account, null, 4), `${window.location.origin}_identity_${UserManager.getUsername()}_encrypted.json`)
                         }
-                    })
-            })
-    });
+                    });
+                return;
+            }
+
+            customPrompts.showConfirm("Generate a QR code?",
+                [["Yes", "success"], ["No", "error"]],
+                (selectedOption) => {
+                    if (selectedOption === "yes") {
+                        let qrcodeElement = document.getElementById("export-account-qrcode");
+
+                        new QRCode(qrcodeElement, {
+                            text: JSON.stringify(UserManager.getShortenedAccountData(response.account)),
+                            correctLevel: QRCode.CorrectLevel.L,
+                            typeNumber: 40,
+                        })
+                    }
+
+                    customPrompts.showConfirm("Export as file?",
+                        [["Yes", "success"], ["No", "error"]],
+                        async (selectedOption2) => {
+                            if (selectedOption2 === "yes") {
+                                await FileManager.saveFile(JSON.stringify(response.account, null, 4), `${window.location.origin}_identity_${UserManager.getUsername()}.json`)
+                            }
+                        })
+                })
+        });
+    };
+
+    customPrompts.showConfirm("Protect the export with a password?",
+        [["Yes", "success"], ["No", "error"]],
+        (selectedOption) => {
+            if (selectedOption !== "yes") {
+                runExport();
+                return;
+            }
+
+            customPrompts.showPrompt(
+                "Protect export",
+                `
+                <div class="prompt-form-group">
+                    <label class="prompt-label" for="exportPassword">Password</label>
+                    <input class="prompt-input" type="password" id="exportPassword" placeholder="Enter export password">
+                </div>
+                `,
+                values => {
+                    const exportPassword = values.exportPassword?.trim();
+                    if (!exportPassword) {
+                        showSystemMessage({
+                            title: "Missing password",
+                            text: "Enter a password to encrypt the export.",
+                            icon: "warning",
+                            img: null,
+                            type: "warning",
+                            duration: 3000
+                        });
+                        return;
+                    }
+
+                    runExport(exportPassword);
+                },
+                ["Protect", "success"],
+                false,
+                420
+            );
+        });
 
     /*
     let data = {
@@ -146,14 +203,49 @@ function importAccount() {
         try {
             let data = JSON.parse(content)
 
-            if (data?.icon) UserManager.setPFP(data.icon);
-            if (data?.banner) UserManager.setBanner(data.banner);
-            if (data?.displayName) UserManager.setUsername(data.displayName);
-            if (data?.status) UserManager.setStatus(data.status);
-            if (data?.aboutme) UserManager.setAboutme(data.aboutme);
+            const applyImportedAccount = importedAccount => {
+                if (importedAccount?.icon) UserManager.setPFP(importedAccount.icon);
+                if (importedAccount?.banner) UserManager.setBanner(importedAccount.banner);
+                if (importedAccount?.name) UserManager.setUsername(importedAccount.name);
+                if (importedAccount?.displayName) UserManager.setUsername(importedAccount.displayName);
+                if (importedAccount?.status) UserManager.setStatus(importedAccount.status);
+                if (importedAccount?.aboutme) UserManager.setAboutme(importedAccount.aboutme);
 
-            // refresh ui
-            setPreview()
+                setPreview()
+            };
+
+            if (data?.encrypted === true) {
+                customPrompts.showPrompt(
+                    "Unlock export",
+                    `
+                    <div class="prompt-form-group">
+                        <label class="prompt-label" for="importPassword">Password</label>
+                        <input class="prompt-input" type="password" id="importPassword" placeholder="Enter export password">
+                    </div>
+                    `,
+                    async values => {
+                        try {
+                            const decryptedAccount = await Crypto.decryptProtectedExport(data, values.importPassword?.trim());
+                            applyImportedAccount(decryptedAccount);
+                        } catch (decryptError) {
+                            showSystemMessage({
+                                title: "Unable to decrypt account",
+                                text: decryptError.message,
+                                icon: "error",
+                                img: null,
+                                type: "error",
+                                duration: 4000
+                            });
+                        }
+                    },
+                    ["Unlock", "success"],
+                    false,
+                    420
+                );
+                return;
+            }
+
+            applyImportedAccount(data);
         } catch (err) {
             console.log(err)
             showSystemMessage({


### PR DESCRIPTION
## Summary

- add optional password-based encryption for exported identity files on the export socket
- normalize exported asset URLs before encrypting so protected exports stay portable
- add import-side decryption so protected account files can still be restored from settings

## Validation

- node --check modules/sockets/exportAccount.mjs
- node --check public/js/core/Crypto.js
- node --check public/settings/account/page/profile/profile.js